### PR TITLE
feat: Material You autocomplete in color editor

### DIFF
--- a/app/src/main/java/com/volume_plus_plus/app/overlay/LiveEditSession.kt
+++ b/app/src/main/java/com/volume_plus_plus/app/overlay/LiveEditSession.kt
@@ -533,11 +533,27 @@ class LiveEditSession(
             topMargin = px(8)
         })
 
-        val actions = LinearLayout(appCtx).apply { orientation = LinearLayout.HORIZONTAL }
+        val actions = LinearLayout(appCtx).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
         actions.addView(textAction(strings.liveEditUseDefault, onBar) { setColorValue(null) })
         actions.addView(textAction(strings.liveEditPickFromScreen, accent) { startEyedropper() })
+        actions.addView(textAction("Material You", accent, bold = true) { applyMaterialYouColors() })
         panel.addView(actions)
 
+        refreshPickerFromSelection()
+    }
+
+    /** Inherit system dynamic Material You palette tokens from the user's device and apply live. */
+    private fun applyMaterialYouColors() {
+        val sysColors = getSystemMaterialYouColors(appCtx, dark)
+        visibleColors(version, config.component).forEach { c ->
+            sysColors[c]?.let { config.withColor(c, it) }
+        }
+        controller.applyLiveColors()
+        rebuildSwatches()
+        refreshSwatchStrokes()
         refreshPickerFromSelection()
     }
 

--- a/app/src/main/java/com/volume_plus_plus/app/overlay/OverlayCustomization.kt
+++ b/app/src/main/java/com/volume_plus_plus/app/overlay/OverlayCustomization.kt
@@ -496,3 +496,64 @@ fun OverlayStyle.applyColors(colors: PanelColors): OverlayStyle = copy(
     doneTextColor = colors.doneText ?: doneTextColor,
     titleColor = colors.title ?: titleColor,
 )
+
+/**
+ * Extract system dynamic Material You palette tokens from the device (Android 12+ / API 31+),
+ * falling back to Material 3 reference colors on older systems.
+ */
+fun getSystemMaterialYouColors(context: android.content.Context, dark: Boolean): Map<EditableColor, Int> {
+    val primary = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_accent1_200 else android.R.color.system_accent1_600)
+    } else android.graphics.Color.parseColor(if (dark) "#FFC1E8FF" else "#FF00668B")
+
+    val primaryContainer = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_accent1_700 else android.R.color.system_accent1_100)
+    } else android.graphics.Color.parseColor(if (dark) "#FF004D68" else "#FFC5E7FF")
+
+    val background = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_neutral1_900 else android.R.color.system_neutral1_50)
+    } else android.graphics.Color.parseColor(if (dark) "#FF1A1C1E" else "#FFFFFFFF")
+
+    val surfaceContainer = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_neutral1_800 else android.R.color.system_neutral1_100)
+    } else android.graphics.Color.parseColor(if (dark) "#FF2B2B2B" else "#FFE8E8E8")
+
+    val onSurface = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_neutral1_100 else android.R.color.system_neutral1_900)
+    } else android.graphics.Color.parseColor(if (dark) "#FFE2E2E5" else "#FF191C1E")
+
+    val onSurfaceVariant = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_neutral2_200 else android.R.color.system_neutral2_700)
+    } else android.graphics.Color.parseColor(if (dark) "#FFC4C7D0" else "#FF44474E")
+
+    val track = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        context.getColor(if (dark) android.R.color.system_accent2_700 else android.R.color.system_accent2_100)
+    } else android.graphics.Color.parseColor(if (dark) "#FF40484D" else "#FFCFE4F2")
+
+    return mapOf(
+        EditableColor.BACKGROUND to background,
+        EditableColor.PROGRESS to primary,
+        EditableColor.TRACK to track,
+        EditableColor.ICON to onSurfaceVariant,
+        EditableColor.ACCENT to primary,
+        EditableColor.TEXT to onSurface,
+        EditableColor.SECONDARY to surfaceContainer,
+        EditableColor.MEDIA_ICON to primary,
+        EditableColor.MODE_ICON to (if (dark) android.graphics.Color.BLACK else android.graphics.Color.WHITE),
+        EditableColor.OVERFLOW to primary,
+        EditableColor.DOT to primary,
+        EditableColor.OUTPUT_SURFACE to surfaceContainer,
+        EditableColor.DONE_BG to primary,
+        EditableColor.DONE_TEXT to (if (dark) android.graphics.Color.BLACK else android.graphics.Color.WHITE),
+        EditableColor.TITLE to onSurface,
+        EditableColor.OUTPUT_CARD to background,
+        EditableColor.OUTPUT_SLIDER to primary,
+        EditableColor.OUTPUT_SLIDER_TRACK to track,
+        EditableColor.OUTPUT_PICKER_ICON to onSurface,
+        EditableColor.OUTPUT_PICKER_TEXT to onSurface,
+        EditableColor.OUTPUT_PICKER_DOT to onSurface,
+        EditableColor.OUTPUT_CONNECT to primary,
+        EditableColor.OUTPUT_DONE to primary,
+        EditableColor.OUTPUT_DONE_TEXT to (if (dark) android.graphics.Color.BLACK else android.graphics.Color.WHITE),
+    )
+}


### PR DESCRIPTION
Adds a button in color editor to autofill the entire palette with the current Material You colors from the device.

Supersedes #10.

Opened another PR since i renamed the branch from the old one